### PR TITLE
Added Volume Support

### DIFF
--- a/Talkie/talkie.h
+++ b/Talkie/talkie.h
@@ -13,6 +13,7 @@ class Talkie
 {
 	public:
 		void say(uint8_t* address);
+		void setVol(uint8_t volume); //Set volume by percentage
 		uint8_t* ptrAddr;
 		uint8_t ptrBit;
 	private:


### PR DESCRIPTION
Hey @going-digital.  I added volume control functionality to your library. It would be great if you could check it out and possibly pull it back into the main branch so others can use it too.

Usage example:
voice.setVol(50); //Set the volume to %50
voice.setVol(100); //Set the volume to %100, original output

It takes one parameter, which is the desired volume in percent, 0-255. A
value of 100 will output the 'Max' volume, which is the normal volume
outputted by the recording.  A value of zero is mute, and a value
greater then 100 will actually boost the original volume.

Careful when boosting, if you go to high, the audio will distort/muffle when
the waveform hits the roof and get clipped.